### PR TITLE
Updates to accept 2023 input, match related events, and date the databases

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,6 @@ from glob import glob
 app = Flask(__name__)
 
 # Access the latest database, unless otherwise specified via command line.
-print(argv)
 if len(argv)==1:
     latest_db = np.sort(glob('*microlensing*.db'))[-1]
     engine = create_engine('sqlite:///'+latest_db)

--- a/app.py
+++ b/app.py
@@ -131,10 +131,10 @@ def plot_lightcurve(alert_name):
     #####
     # Get the year of the alert.
     YY = alert_name[2:4]
-    
+
     # The *1 is just a dumb trick to turn it into an integer.
     year = ne.evaluate(YY) * 1 
-    
+
     # HJD date corresponding to 1 January 2000.
     hjd_jan_00 = 1154
 
@@ -146,7 +146,7 @@ def plot_lightcurve(alert_name):
     
     # Now only keep things from the year of and before.
     keep_idx = np.where((time < end_date) & (time > start_date))[0]
-    
+
     # Finally... make the plot.
     fig = create_figure(time[keep_idx], mag[keep_idx], mag_err[keep_idx], alert_name)
     

--- a/populate_database.py
+++ b/populate_database.py
@@ -1,17 +1,18 @@
 import query_alerts
-from importlib import reload
-reload(query_alerts)
 
-'''query_alerts.get_moa_lightcurves(2022)
-print('Downloaded MOA photometry from 2022 to database.')
-query_alerts.get_ogle_lightcurves(2019)
-print('Downloaded OGLE photometry from 2019 to database.')
-query_alerts.get_kmtnet_lightcurves(2022)
-print('Downloaded KMTNet photometry from 2022 to database.')'''
-
-#query_alerts.get_moa_alerts(2023)
-#print('Downloaded MOA alerts from 2023 to database.')
-#query_alerts.get_ogle_alerts(2023)
-#print('Downloaded OGLE alerts from 2023 to database.')
+# Get alerts
+query_alerts.get_moa_alerts(2023)
+print('Downloaded MOA alerts from 2023 to database.')
+query_alerts.get_ogle_alerts(2023)
+print('Downloaded OGLE alerts from 2023 to database.')
 query_alerts.get_kmtnet_alerts(2023)
 print('Downloaded KMTNet alerts from 2023 to database.')
+
+# Get light curves
+query_alerts.get_moa_lightcurves(2023)
+print('Downloaded MOA photometry from 2023 to database.')
+query_alerts.get_ogle_lightcurves(2023)
+print('Downloaded OGLE photometry from 2023 to database.')
+query_alerts.get_kmtnet_lightcurves(2023)
+print('Downloaded KMTNet photometry from 2023 to database.')
+

--- a/populate_database.py
+++ b/populate_database.py
@@ -1,15 +1,17 @@
 import query_alerts
+from importlib import reload
+reload(query_alerts)
 
-query_alerts.get_moa_lightcurves(2022)
+'''query_alerts.get_moa_lightcurves(2022)
 print('Downloaded MOA photometry from 2022 to database.')
 query_alerts.get_ogle_lightcurves(2019)
 print('Downloaded OGLE photometry from 2019 to database.')
 query_alerts.get_kmtnet_lightcurves(2022)
-print('Downloaded KMTNet photometry from 2022 to database.')
+print('Downloaded KMTNet photometry from 2022 to database.')'''
 
-query_alerts.get_moa_alerts(2022)
-print('Downloaded MOA alerts from 2022 to database.')
-query_alerts.get_ogle_alerts(2019)
-print('Downloaded OGLE alerts from 2019 to database.')
-query_alerts.get_kmtnet_alerts(2022)
-print('Downloaded KMTNet alerts from 2022 to database.')
+#query_alerts.get_moa_alerts(2023)
+#print('Downloaded MOA alerts from 2023 to database.')
+#query_alerts.get_ogle_alerts(2023)
+#print('Downloaded OGLE alerts from 2023 to database.')
+query_alerts.get_kmtnet_alerts(2023)
+print('Downloaded KMTNet alerts from 2023 to database.')

--- a/query_alerts.py
+++ b/query_alerts.py
@@ -217,6 +217,7 @@ def get_kmtnet_lightcurves(year):
                 # Grab the photometry for each alert's I-band lightcurve data into a pands dataframe.
                 url = "https://kmtnet.kasi.re.kr/~ulens/event/" + year + "/data/KB" + \
                         year[2:] + str(nn).zfill(4) + "/pysis/" + pysis_name
+
                 bytes_data = requests.get(url).content
                 df = pd.read_csv(BytesIO(bytes_data), 
                                  delim_whitespace=True, skiprows=1, header=None, 
@@ -227,6 +228,9 @@ def get_kmtnet_lightcurves(year):
                 # and telescope (lightcurve's pysis file.)
                 df['alert_name'] = 'KB' + year[2:] + str(nn).zfill(4) 
                 df['telescope'] = pysis_name
+                
+                # Write HJD as HJD - 2450000 (less cumbersome digits)
+                df['hjd'] -= 2450000
 
                 # Write out the HJD, mag, mag_err, telescope, and alert_name data into the table.
                 cols = ['hjd', 'mag', 'mag_err', 'telescope', 'alert_name']


### PR DESCRIPTION
A number of updates:
- OGLE alerts and light curves now allow for DG and GD events, in addition to BLG
- KMTNet alerts now allow for the year 2023
- The alerts database now includes a new column related_event for events detected by more than one alert system
   - MOA includes related OGLE events
   - OGLE does not provide related events
   - KMTNet provides related events from both MOA and OGLE
- Running query_alerts.py now names the database with the current date (YYYY-MM-DD).
   - If rerun on the same date, the new data is appended.
   - Else, a new database is created.
- Running app.py now opens the latest database version, or what the user enters via command line argument.